### PR TITLE
Updated nix dependency version to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpio-cdev"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Paul Osborne <osbpau@gmail.com>", "Frank Pagliughi <fpagliughi@mindspring.com>"]
 description = "Linux GPIO Character Device Support (/dev/gpiochipN)"
 homepage = "https://github.com/posborne/rust-gpio-cdev"
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 bitflags = "1.0"
 error-chain = "0.12"
 libc = "0.2"
-nix = "0.11"
+nix = "0.14"
 
 [dev-dependencies]
 quicli = "0.2"

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -15,7 +15,7 @@ use quicli::prelude::*;
 use nix::poll::*;
 use std::os::unix::io::{AsRawFd};
 
-type PollEventFlags = nix::poll::EventFlags;
+type PollEventFlags = nix::poll::PollFlags;
 
 #[derive(Debug, StructOpt)]
 struct Cli {


### PR DESCRIPTION
This fixes the compilation error on a Raspberry Pi Zero W (and presumably other armhf7 devices).