### PR TITLE
Fixed deprecation warnings for libc::uint32_t, etc

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -15,45 +15,45 @@ pub const GPIOHANDLES_MAX: usize = 64;
 pub struct gpiochip_info {
     pub name: [libc::c_char; 32],
     pub label: [libc::c_char; 32],
-    pub lines: libc::uint32_t,
+    pub lines: u32,
 }
 
 #[repr(C)]
 pub struct gpioline_info {
-    pub line_offset: libc::uint32_t,
-    pub flags: libc::uint32_t,
+    pub line_offset: u32,
+    pub flags: u32,
     pub name: [libc::c_char; 32],
     pub consumer: [libc::c_char; 32],
 }
 
 #[repr(C)]
 pub struct gpiohandle_request {
-    pub lineoffsets: [libc::uint32_t; GPIOHANDLES_MAX],
-    pub flags: libc::uint32_t,
-    pub default_values: [libc::uint8_t; GPIOHANDLES_MAX],
+    pub lineoffsets: [u32; GPIOHANDLES_MAX],
+    pub flags: u32,
+    pub default_values: [u8; GPIOHANDLES_MAX],
     pub consumer_label: [libc::c_char; 32],
-    pub lines: libc::uint32_t,
+    pub lines: u32,
     pub fd: libc::c_int,
 }
 
 #[repr(C)]
 pub struct gpiohandle_data {
-    pub values: [libc::uint8_t; GPIOHANDLES_MAX],
+    pub values: [u8; GPIOHANDLES_MAX],
 }
 
 #[repr(C)]
 pub struct gpioevent_request {
-    pub lineoffset: libc::uint32_t,
-    pub handleflags: libc::uint32_t,
-    pub eventflags: libc::uint32_t,
+    pub lineoffset: u32,
+    pub handleflags: u32,
+    pub eventflags: u32,
     pub consumer_label: [libc::c_char; 32],
     pub fd: libc::c_int,
 }
 
 #[repr(C)]
 pub struct gpioevent_data {
-    pub timestamp: libc::uint64_t,
-    pub id: libc::uint32_t,
+    pub timestamp: u64,
+    pub id: u32,
 }
 
 ioctl_read!(gpio_get_chipinfo_ioctl, 0xB4, 0x01, gpiochip_info);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ pub struct LineInfo {
 ///
 /// [`GPIOHANDLE_REQUEST_*`]: https://elixir.bootlin.com/linux/v4.9.127/source/include/uapi/linux/gpio.h#L58
 bitflags! {
-    pub struct LineRequestFlags: libc::uint32_t {
+    pub struct LineRequestFlags: u32 {
         const INPUT = (1 << 0);
         const OUTPUT = (1 << 1);
         const ACTIVE_LOW = (1 << 2);
@@ -350,7 +350,7 @@ bitflags! {
 ///
 /// [`GPIOEVENT_REQUEST_*`]: https://elixir.bootlin.com/linux/v4.9.127/source/include/uapi/linux/gpio.h#L109
 bitflags! {
-    pub struct EventRequestFlags: libc::uint32_t {
+    pub struct EventRequestFlags: u32 {
         const RISING_EDGE = (1 << 0);
         const FALLING_EDGE = (1 << 1);
         const BOTH_EDGES = Self::RISING_EDGE.bits | Self::FALLING_EDGE.bits;
@@ -363,7 +363,7 @@ bitflags! {
 ///
 /// [`GPIOLINE_FLAG_*`]: https://elixir.bootlin.com/linux/v4.9.127/source/include/uapi/linux/gpio.h#L29
 bitflags! {
-    pub struct LineFlags: libc::uint32_t {
+    pub struct LineFlags: u32 {
         const KERNEL = (1 << 0);
         const IS_OUT = (1 << 1);
         const ACTIVE_LOW = (1 << 2);


### PR DESCRIPTION
With Rust v1.37.0, I'm getting compiler warnings about the libc integer types being obsolete, like:
```
warning: use of deprecated item 'libc::uint32_t': Use u32 instead.
   --> src/lib.rs:338:34
    |
338 |     pub struct LineRequestFlags: libc::uint32_t {
    |                                  ^^^^^^^^^^^^^^
    |
    = note: #[warn(deprecated)] on by default
```
This fixes the code as recommended by the compiler.