### PR TITLE
ci: fix travis config to also build staging branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,12 +102,6 @@ before_cache:
   # Travis can't cache files that are not readable by "others"
   - chmod -R a+r $HOME/.cargo
 
-branches:
-  only:
-    # release tags
-    - /^v\d+\.\d+\.\d+.*$/
-    - master
-
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
As part of the post-transfer, the required config for bors was added
to the config but this older definition for branches was not removed
and was still be used.  As a result, travis was not building the
staging branch and bors was timing out waiting for CI results.