### PR TITLE
Closes #28: Version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## v0.3.0 - 2020-02-10
+
+Refactored Errors:
+- Removed the `error-chain` dependency.
+- Errors are now implemented "manually" with `ErrorKind` and `IoctlKind` enums. 
+- The encompassing `Error` type implements the `std::error::Error` trait.
+
 ## v0.2.0 - 2018-12-12
 
 Adds the ability to create a collection of lines from a single chip and read or write those lines simultaneously with a single stystem call.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpio-cdev"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Paul Osborne <osbpau@gmail.com>", "Frank Pagliughi <fpagliughi@mindspring.com>"]
 description = "Linux GPIO Character Device Support (/dev/gpiochipN)"
 homepage = "https://github.com/posborne/rust-gpio-cdev"


### PR DESCRIPTION
Closes #28:
- Documents changes to errors in CHANGELOG.md
- Bumps crate version
