### PR TITLE
Add `libgpio`, `libgpiod` and `gpiod` to keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/posborne/rust-gpio-cdev"
 repository = "https://github.com/posborne/rust-gpio-cdev"
 readme = "README.md"
 categories = ["embedded", "hardware-support", "os", "os::unix-apis"]
-keywords = ["linux", "gpio", "gpiochip", "embedded"]
+keywords = ["linux", "gpio", "gpiochip", "embedded", "libgpio", "libgpiod", "gpiod"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 


### PR DESCRIPTION
The reason is, that I didn't find this crate until I was very desperate and only stumpled upon it by [this](https://github.com/rust-embedded/wg/issues/46#issuecomment-379570127) comment.

Even today if I google `rust "libgpiod"` I can't find this place.

I often try to google the c library counterpart together with the keyword rust to see if I can find something that suits my needs. This crate does, however it's not easy to find.

Maybe this PR can be extended to update the `README.md` and mention it there as well.