### PR TITLE
Prep 0.4.0, Error changes, MSRV Bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
 
     # MSRV
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: 1.38.0
+      rust: 1.39.0
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v0.4.0 - 2020-08-01
 
+- Removed pub "errors" module.  Error now exposed at top level.
 - MSRV is now 1.39.0
 - Add support behind a feature flag for reading events from a line as a Stream via tokio. [#35](https://github.com/rust-embedded/gpio-cdev/pull/35).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v0.4.0 - 2020-08-01
 
+- MSRV is now 1.39.0
 - Add support behind a feature flag for reading events from a line as a Stream via tokio. [#35](https://github.com/rust-embedded/gpio-cdev/pull/35).
 
 ## v0.3.0 - 2020-02-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## v0.4.0 - 2020-08-01
+
+- Add support behind a feature flag for reading events from a line as a Stream via tokio. [#35](https://github.com/rust-embedded/gpio-cdev/pull/35).
+
 ## v0.3.0 - 2020-02-10
 
 Refactored Errors:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpio-cdev"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Paul Osborne <osbpau@gmail.com>", "Frank Pagliughi <fpagliughi@mindspring.com>"]
 description = "Linux GPIO Character Device Support (/dev/gpiochipN)"
 homepage = "https://github.com/posborne/rust-gpio-cdev"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ use gpio_cdev::{Chip, LineRequestFlags, EventRequestFlags, EventType};
 // on gpiochip0 and mirror its state on another line.  With this you
 // could, for instance, control the state of an LED with a button
 // if hooked up to the right pins on a raspberry pi.
-fn mirror_gpio(inputline: u32, outputline: u32) -> gpio_cdev::errors::Result<()> {
+fn mirror_gpio(inputline: u32, outputline: u32) -> Result<(), gpio_cdev::Error> {
     let mut chip = Chip::new("/dev/gpiochip0")?;
     let input = chip.get_line(inputline)?;
     let output = chip.get_line(outputline)?;
@@ -96,9 +96,8 @@ Note that this requires the addition of the `async-tokio` feature.
 ```rust
 use futures::stream::StreamExt;
 use gpio_cdev::{Chip, AsyncLineEventHandle};
-use gpio_cdev::errors::Error;
 
-async fn gpiomon(chip: String, line: u32) -> Result<(), Error> {
+async fn gpiomon(chip: String, line: u32) -> gpio_cdev::Result<()> {
     let mut chip = Chip::new(args.chip)?;
     let line = chip.get_line(args.line)?;
     let mut events = AsyncLineEventHandle::new(line.events(

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ to be considered reliable.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.38.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.39.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,15 +3,15 @@
 set -ex
 
 main() {
-    cross build --target $TARGET
-    cross build --target $TARGET --release
+    cross build --target $TARGET --all-features
+    cross build --target $TARGET --release --all-features
 
     if [ ! -z $DISABLE_TESTS ]; then
         return
     fi
 
-    cross test --target $TARGET
-    cross test --target $TARGET --release
+    cross test --target $TARGET --all-features
+    cross test --target $TARGET --release --all-features
 
     # No main binary, so skip the 'cross run' portion
     # cross run --target $TARGET

--- a/examples/async_tokio.rs
+++ b/examples/async_tokio.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use futures::stream::StreamExt;
-use gpio_cdev::*;
+use gpio_cdev::{AsyncLineEventHandle, Chip, EventRequestFlags, LineRequestFlags};
 use quicli::prelude::*;
 
 #[derive(Debug, StructOpt)]
@@ -18,7 +18,7 @@ struct Cli {
     line: u32,
 }
 
-async fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
+async fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     let mut chip = Chip::new(args.chip)?;
     let line = chip.get_line(args.line)?;
     let mut events = AsyncLineEventHandle::new(line.events(

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -6,15 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate gpio_cdev;
-#[macro_use]
-extern crate quicli;
-
-use gpio_cdev::*;
+use gpio_cdev::{Chip, LineRequestFlags};
 use quicli::prelude::*;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
-
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -28,7 +23,7 @@ struct Cli {
     duration_ms: u64,
 }
 
-fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
+fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     let mut chip = Chip::new(args.chip)?;
 
     // NOTE: we set the default value to the desired state so
@@ -49,7 +44,7 @@ fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
     Ok(())
 }
 
-main!(|args: Cli| match do_main(args) {
+quicli::main!(|args: Cli| match do_main(args) {
     Ok(()) => {}
     Err(e) => {
         println!("Error: {:?}", e);

--- a/examples/driveoutput.rs
+++ b/examples/driveoutput.rs
@@ -6,11 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate gpio_cdev;
-#[macro_use]
-extern crate quicli;
-
-use gpio_cdev::*;
+use gpio_cdev::{Chip, LineRequestFlags};
 use quicli::prelude::*;
 
 #[derive(Debug, StructOpt)]
@@ -23,7 +19,7 @@ struct Cli {
     value: u8,
 }
 
-fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
+fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     let mut chip = Chip::new(args.chip)?;
 
     // NOTE: we set the default value to the desired state so
@@ -44,7 +40,7 @@ fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
     Ok(())
 }
 
-main!(|args: Cli| match do_main(args) {
+quicli::main!(|args: Cli| match do_main(args) {
     Ok(()) => {}
     Err(e) => {
         println!("Error: {:?}", e);

--- a/examples/gpioevents.rs
+++ b/examples/gpioevents.rs
@@ -6,13 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate gpio_cdev;
-#[macro_use]
-extern crate quicli;
-
-use gpio_cdev::*;
+use gpio_cdev::{Chip, EventRequestFlags, LineRequestFlags};
 use quicli::prelude::*;
-
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -22,7 +17,7 @@ struct Cli {
     line: u32,
 }
 
-fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
+fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     let mut chip = Chip::new(args.chip)?;
     let line = chip.get_line(args.line)?;
 
@@ -37,7 +32,7 @@ fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
     Ok(())
 }
 
-main!(|args: Cli| match do_main(args) {
+quicli::main!(|args: Cli| match do_main(args) {
     Ok(()) => {}
     Err(e) => {
         println!("Error: {:?}", e);

--- a/examples/multioutput.rs
+++ b/examples/multioutput.rs
@@ -6,11 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate gpio_cdev;
-#[macro_use]
-extern crate quicli;
-
-use gpio_cdev::*;
+use gpio_cdev::{Chip, LineRequestFlags};
 use quicli::prelude::*;
 
 #[derive(Debug, StructOpt)]
@@ -28,7 +24,7 @@ struct Cli {
 // to set lines 0, 1, & 3 high
 //              2 & 4 low
 //
-fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
+fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     let mut chip = Chip::new(args.chip)?;
     let mut offsets = Vec::new();
     let mut values = Vec::new();
@@ -52,7 +48,7 @@ fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
     Ok(())
 }
 
-main!(|args: Cli| match do_main(args) {
+quicli::main!(|args: Cli| match do_main(args) {
     Ok(()) => {}
     Err(e) => {
         println!("Error: {:?}", e);

--- a/examples/multiread.rs
+++ b/examples/multiread.rs
@@ -6,11 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate gpio_cdev;
-#[macro_use]
-extern crate quicli;
-
-use gpio_cdev::*;
+use gpio_cdev::{Chip, LineRequestFlags};
 use quicli::prelude::*;
 
 #[derive(Debug, StructOpt)]
@@ -21,18 +17,18 @@ struct Cli {
     lines: Vec<u32>,
 }
 
-fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
+fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     let mut chip = Chip::new(args.chip)?;
-    let ini_vals = vec![ 0; args.lines.len() ];
-    let handle = chip
-        .get_lines(&args.lines)?
-        .request(LineRequestFlags::INPUT, &ini_vals, "multiread")?;
+    let ini_vals = vec![0; args.lines.len()];
+    let handle =
+        chip.get_lines(&args.lines)?
+            .request(LineRequestFlags::INPUT, &ini_vals, "multiread")?;
     println!("Values: {:?}", handle.get_values()?);
 
     Ok(())
 }
 
-main!(|args: Cli| match do_main(args) {
+quicli::main!(|args: Cli| match do_main(args) {
     Ok(()) => {}
     Err(e) => {
         println!("Error: {:?}", e);

--- a/examples/readall.rs
+++ b/examples/readall.rs
@@ -6,11 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate gpio_cdev;
-#[macro_use]
-extern crate quicli;
-
-use gpio_cdev::*;
+use gpio_cdev::{Chip, LineRequestFlags};
 use quicli::prelude::*;
 
 #[derive(Debug, StructOpt)]
@@ -19,7 +15,7 @@ struct Cli {
     chip: String,
 }
 
-fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
+fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     let mut chip = Chip::new(args.chip)?;
     let ini_vals = vec![0; chip.num_lines() as usize];
     let handle = chip
@@ -30,7 +26,7 @@ fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
     Ok(())
 }
 
-main!(|args: Cli| match do_main(args) {
+quicli::main!(|args: Cli| match do_main(args) {
     Ok(()) => {}
     Err(e) => {
         println!("Error: {:?}", e);

--- a/examples/readinput.rs
+++ b/examples/readinput.rs
@@ -6,11 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate gpio_cdev;
-#[macro_use]
-extern crate quicli;
-
-use gpio_cdev::*;
+use gpio_cdev::{Chip, LineRequestFlags};
 use quicli::prelude::*;
 
 #[derive(Debug, StructOpt)]
@@ -21,7 +17,7 @@ struct Cli {
     line: u32,
 }
 
-fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
+fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     let mut chip = Chip::new(args.chip)?;
     let handle = chip
         .get_line(args.line)?
@@ -31,7 +27,7 @@ fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
     Ok(())
 }
 
-main!(|args: Cli| match do_main(args) {
+quicli::main!(|args: Cli| match do_main(args) {
     Ok(()) => {}
     Err(e) => {
         println!("Error: {:?}", e);

--- a/examples/tit_for_tat.rs
+++ b/examples/tit_for_tat.rs
@@ -6,15 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate gpio_cdev;
-#[macro_use]
-extern crate quicli;
-
-use gpio_cdev::*;
+use gpio_cdev::{Chip, EventRequestFlags, EventType, LineRequestFlags};
 use quicli::prelude::*;
 use std::thread::sleep;
 use std::time::Duration;
-
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -28,7 +23,7 @@ struct Cli {
     sleeptime: u64,
 }
 
-fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
+fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     let mut chip = Chip::new(args.chip)?;
     let input = chip.get_line(args.inputline)?;
     let output = chip.get_line(args.outputline)?;
@@ -59,7 +54,7 @@ fn do_main(args: Cli) -> std::result::Result<(), errors::Error> {
     Ok(())
 }
 
-main!(|args: Cli| match do_main(args) {
+quicli::main!(|args: Cli| match do_main(args) {
     Ok(()) => {}
     Err(e) => {
         println!("Error: {:?}", e);

--- a/src/async_tokio.rs
+++ b/src/async_tokio.rs
@@ -20,7 +20,7 @@ use std::io;
 use std::os::unix::io::AsRawFd;
 use std::pin::Pin;
 
-use super::errors::event_err;
+use super::event_err;
 use super::{LineEvent, LineEventHandle, Result};
 
 struct PollWrapper {
@@ -60,11 +60,10 @@ impl Evented for PollWrapper {
 /// The following example waits for state changes on an input line.
 ///
 /// ```no_run
-/// # type Result<T> = std::result::Result<T, gpio_cdev::errors::Error>;
 /// use futures::stream::StreamExt;
 /// use gpio_cdev::{AsyncLineEventHandle, Chip, EventRequestFlags, LineRequestFlags};
 ///
-/// async fn print_events(line: u32) -> Result<()> {
+/// async fn print_events(line: u32) -> Result<(), gpio_cdev::Error> {
 ///     let mut chip = Chip::new("/dev/gpiochip0")?;
 ///     let line = chip.get_line(line)?;
 ///     let mut events = AsyncLineEventHandle::new(line.events(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,8 @@
+//! This module is deprecated and types are exported from the top-level of the crate
+//!
+//! In futures versions of the crate, this module will no longer be included in the crate.
+
+use crate::IoctlKind;
 use std::error::Error as StdError;
 use std::fmt;
 use std::io::Error as IOError;
@@ -7,16 +12,6 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug)]
 pub struct Error {
     kind: ErrorKind,
-}
-
-#[derive(Debug)]
-pub enum IoctlKind {
-    ChipInfo,
-    LineInfo,
-    LineHandle,
-    LineEvent,
-    GetLine,
-    SetLine,
 }
 
 #[derive(Debug)]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::errors::IoctlKind;
+use crate::IoctlKind;
 use libc;
 
 pub const GPIOHANDLES_MAX: usize = 64;


### PR DESCRIPTION
* Prep 0.4.0 Release
* Deperecate odd errors module and expose via re-export at top-level (argument could be made to just rip the band-aid off here or to not make the change at all).
* Fix testing to cover async changes and MSRV to be compatible with those (we are doing a major version bump so this is OK) 
* Add some more docs content for the async changes