### PR TITLE
Document `async-tokio` feature on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,9 @@ mio = { version = "0.6", optional = true }
 [dev-dependencies]
 quicli = "0.2"
 anyhow = "1.0"
+
+[package.metadata.docs.rs]
+# To build locally:
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,8 @@
 //!
 //! [README on Github]: https://github.com/rust-embedded/rust-gpio-cdev
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
@@ -99,6 +101,7 @@ use std::slice;
 use std::sync::Arc;
 
 #[cfg(feature = "async-tokio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-tokio")))]
 mod async_tokio;
 pub mod errors; // pub portion is deprecated
 mod ffi;
@@ -114,6 +117,7 @@ pub enum IoctlKind {
 }
 
 #[cfg(feature = "async-tokio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-tokio")))]
 pub use crate::async_tokio::AsyncLineEventHandle;
 pub use errors::*;
 
@@ -562,6 +566,7 @@ impl Line {
     }
 
     #[cfg(feature = "async-tokio")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "async-tokio")))]
     pub fn async_events(
         &self,
         handle_flags: LineRequestFlags,


### PR DESCRIPTION
Documents things behind features on docs.rs

<img width="483" alt="Screen Shot 2021-01-11 at 5 51 44 PM" src="https://user-images.githubusercontent.com/2488926/104259235-e06a6100-5435-11eb-9632-bb04e7fea292.png">
<img width="782" alt="Screen Shot 2021-01-11 at 5 51 18 PM" src="https://user-images.githubusercontent.com/2488926/104259239-e2342480-5435-11eb-8057-8b81ab3afa91.png">
