### PR TITLE
Disable tests for the MSRV on CI since support was broken by a dependency

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,3 +2,4 @@ block_labels = ["needs-decision"]
 delete_merged_branches = true
 required_approvals = 1
 status = ["continuous-integration/travis-ci/push"]
+timeout_sec = 7200

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     # MSRV
-    - env: TARGET=x86_64-unknown-linux-gnu
+    - env: TARGET=x86_64-unknown-linux-gnu DISABLE_TESTS=1
       rust: 1.39.0
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 


### PR DESCRIPTION
`object` dependency broke the support for the current 1.39.0 MSRV.
```
error[E0658]: the `#[non_exhaustive]` attribute is an experimental feature
   --> /cargo/registry/src/github.com-1ecc6299db9ec823/object-0.23.0/src/read/mod.rs:114:1
    |
114 | #[non_exhaustive]
    | ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44109
error[E0658]: subslice patterns are unstable
   --> /cargo/registry/src/github.com-1ecc6299db9ec823/object-0.23.0/src/read/mod.rs:162:41
    |
162 |             [0x7f, b'E', b'L', b'F', 1, ..] => FileKind::Elf32,
    |                                         ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/62254
```

`cargo tree`:
```
gpio-cdev v0.4.0 (/home/dbarriosromero/projects/rust/gpio-cdev)
├── bitflags v1.2.1
├── libc v0.2.86
└── nix v0.14.1
    ├── bitflags v1.2.1
    ├── cfg-if v0.1.10
    ├── libc v0.2.86
    └── void v1.0.2
[dev-dependencies]
├── anyhow v1.0.38
└── quicli v0.2.0
    ├── env_logger v0.5.13
    │   ├── atty v0.2.14
    │   │   └── libc v0.2.86
    │   ├── humantime v1.3.0
    │   │   └── quick-error v1.2.3
    │   ├── log v0.4.14
    │   │   └── cfg-if v1.0.0
    │   ├── regex v1.4.3
    │   │   ├── aho-corasick v0.7.15
    │   │   │   └── memchr v2.3.4
    │   │   ├── memchr v2.3.4
    │   │   ├── regex-syntax v0.6.22
    │   │   └── thread_local v1.1.3
    │   │       └── once_cell v1.5.2
    │   └── termcolor v1.1.2
    ├── failure v0.1.8
    │   ├── backtrace v0.3.56
    │   │   ├── addr2line v0.14.1
    │   │   │   └── gimli v0.23.0
    │   │   ├── cfg-if v1.0.0
    │   │   ├── libc v0.2.86
    │   │   ├── miniz_oxide v0.4.3
    │   │   │   └── adler v0.2.3
    │   │   │   [build-dependencies]
    │   │   │   └── autocfg v1.0.1
    │   │   ├── object v0.23.0
    │   │   └── rustc-demangle v0.1.18
    │   └── failure_derive v0.1.8
    │       ├── proc-macro2 v1.0.24
    │       │   └── unicode-xid v0.2.1
    │       ├── quote v1.0.8
    │       │   └── proc-macro2 v1.0.24 (*)
    │       ├── syn v1.0.60
    │       │   ├── proc-macro2 v1.0.24 (*)
    │       │   ├── quote v1.0.8 (*)
    │       │   └── unicode-xid v0.2.1
    │       └── synstructure v0.12.4
    │           ├── proc-macro2 v1.0.24 (*)
    │           ├── quote v1.0.8 (*)
    │           ├── syn v1.0.60 (*)
    │           └── unicode-xid v0.2.1
    ├── failure_derive v0.1.8 (*)
    ├── glob v0.2.11
    ├── log v0.4.14 (*)
    ├── rayon v0.9.0
    │   ├── either v1.6.1
    │   └── rayon-core v1.9.0
    │       ├── crossbeam-channel v0.5.0
    │       │   ├── cfg-if v1.0.0
    │       │   └── crossbeam-utils v0.8.1
    │       │       ├── cfg-if v1.0.0
    │       │       └── lazy_static v1.4.0
    │       │       [build-dependencies]
    │       │       └── autocfg v1.0.1
    │       ├── crossbeam-deque v0.8.0
    │       │   ├── cfg-if v1.0.0
    │       │   ├── crossbeam-epoch v0.9.1
    │       │   │   ├── cfg-if v1.0.0
    │       │   │   ├── const_fn v0.4.5
    │       │   │   ├── crossbeam-utils v0.8.1 (*)
    │       │   │   ├── lazy_static v1.4.0
    │       │   │   ├── memoffset v0.6.1
    │       │   │   │   [build-dependencies]
    │       │   │   │   └── autocfg v1.0.1
    │       │   │   └── scopeguard v1.1.0
    │       │   └── crossbeam-utils v0.8.1 (*)
    │       ├── crossbeam-utils v0.8.1 (*)
    │       ├── lazy_static v1.4.0
    │       └── num_cpus v1.13.0
    │           └── libc v0.2.86
    ├── serde v1.0.123
    ├── serde_derive v1.0.123
    │   ├── proc-macro2 v1.0.24 (*)
    │   ├── quote v1.0.8 (*)
    │   └── syn v1.0.60 (*)
    ├── structopt v0.2.18
    │   ├── clap v2.33.3
    │   │   ├── ansi_term v0.11.0
    │   │   ├── atty v0.2.14 (*)
    │   │   ├── bitflags v1.2.1
    │   │   ├── strsim v0.8.0
    │   │   ├── textwrap v0.11.0
    │   │   │   └── unicode-width v0.1.8
    │   │   ├── unicode-width v0.1.8
    │   │   └── vec_map v0.8.2
    │   └── structopt-derive v0.2.18
    │       ├── heck v0.3.2
    │       │   └── unicode-segmentation v1.7.1
    │       ├── proc-macro2 v0.4.30
    │       │   └── unicode-xid v0.1.0
    │       ├── quote v0.6.13
    │       │   └── proc-macro2 v0.4.30 (*)
    │       └── syn v0.15.44
    │           ├── proc-macro2 v0.4.30 (*)
    │           ├── quote v0.6.13 (*)
    │           └── unicode-xid v0.1.0
    └── structopt-derive v0.2.18 (*)
```
