### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Update Tokio to 1.x. #[55]((https://github.com/rust-embedded/gpio-cdev/pull/55).
 - Breaking change of `LineEventHandle::get_event()` which now expects `&mut self`.
 - MSRV is now 1.45.0
+- Updated `nix` to version `0.20`.
+- Updated `quicli` to version `0.4`.
 
 
 ## v0.4.0 - 2020-08-01
@@ -27,17 +29,17 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 Refactored Errors:
 - Removed the `error-chain` dependency.
-- Errors are now implemented "manually" with `ErrorKind` and `IoctlKind` enums. 
+- Errors are now implemented "manually" with `ErrorKind` and `IoctlKind` enums.
 - The encompassing `Error` type implements the `std::error::Error` trait.
 
 ## v0.2.0 - 2018-12-12
 
 Adds the ability to create a collection of lines from a single chip and read or write those lines simultaneously with a single stystem call.
- 
+
 - A new `Lines` object (plural) was added. It is a collection of individual `Line` objects on a single `Chip` which can be read or written simultaneously with a single system call.
 - A `Line` now just contains the reference to the Chip and the offset number. No system call is incurred when one is created.
 - Information about an individual line is now represented by a separate `LineInfo` struct which can be obtained from the function `Line::info()`. This incurs a system call to retrieve the information.
-- Creating a `Line` can't fail unless the caller specifies an offset that is out of range of the chip. 
+- Creating a `Line` can't fail unless the caller specifies an offset that is out of range of the chip.
 - The `LineIterator` can not fail since it checks the offset range. So now its item is just a `Line`, and not `Result<Line>`.
 - There was no longer a need for `Line::refresh()` so it was removed.
 - Since a `Line` object is trivial to create, it is now OK to have `Lines` be a simple collection of `Line` structs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,13 @@ required-features = ["async-tokio"]
 [dependencies]
 bitflags = "1.0"
 libc = "0.2"
-nix = "0.14"
+nix = "0.20"
 tokio = { version = "1", features = ["io-std", "net"], optional = true }
 futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
-quicli = "0.2"
+quicli = "0.4"
+structopt = "0.3"
 anyhow = "1.0"
 tokio = { version = "1", features = ["io-std", "rt-multi-thread", "macros", "net"] }
 

--- a/examples/async_tokio.rs
+++ b/examples/async_tokio.rs
@@ -8,7 +8,7 @@
 
 use futures::stream::StreamExt;
 use gpio_cdev::{AsyncLineEventHandle, Chip, EventRequestFlags, LineRequestFlags};
-use quicli::prelude::*;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Cli {

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -10,6 +10,7 @@ use gpio_cdev::{Chip, LineRequestFlags};
 use quicli::prelude::*;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -44,9 +45,10 @@ fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     Ok(())
 }
 
-quicli::main!(|args: Cli| match do_main(args) {
-    Ok(()) => {}
-    Err(e) => {
-        println!("Error: {:?}", e);
-    }
-});
+fn main() -> CliResult {
+    let args = Cli::from_args();
+    do_main(args).or_else(|e| {
+        error!("{:?}", e);
+        Ok(())
+    })
+}

--- a/examples/driveoutput.rs
+++ b/examples/driveoutput.rs
@@ -8,6 +8,7 @@
 
 use gpio_cdev::{Chip, LineRequestFlags};
 use quicli::prelude::*;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -40,9 +41,10 @@ fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     Ok(())
 }
 
-quicli::main!(|args: Cli| match do_main(args) {
-    Ok(()) => {}
-    Err(e) => {
-        println!("Error: {:?}", e);
-    }
-});
+fn main() -> CliResult {
+    let args = Cli::from_args();
+    do_main(args).or_else(|e| {
+        error!("{:?}", e);
+        Ok(())
+    })
+}

--- a/examples/gpioevents.rs
+++ b/examples/gpioevents.rs
@@ -8,6 +8,7 @@
 
 use gpio_cdev::{Chip, EventRequestFlags, LineRequestFlags};
 use quicli::prelude::*;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -32,9 +33,10 @@ fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     Ok(())
 }
 
-quicli::main!(|args: Cli| match do_main(args) {
-    Ok(()) => {}
-    Err(e) => {
-        println!("Error: {:?}", e);
-    }
-});
+fn main() -> CliResult {
+    let args = Cli::from_args();
+    do_main(args).or_else(|e| {
+        error!("{:?}", e);
+        Ok(())
+    })
+}

--- a/examples/lsgpio.rs
+++ b/examples/lsgpio.rs
@@ -8,8 +8,6 @@
 
 //! Clone of functionality of linux/tools/gpio/lsgpio.c
 
-extern crate gpio_cdev;
-
 use gpio_cdev::*;
 
 fn main() {

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -6,16 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate gpio_cdev;
-extern crate nix;
-#[macro_use]
-extern crate quicli;
-extern crate anyhow;
-
 use gpio_cdev::*;
 use nix::poll::*;
 use quicli::prelude::*;
 use std::os::unix::io::AsRawFd;
+use structopt::StructOpt;
 
 type PollEventFlags = nix::poll::PollFlags;
 
@@ -82,11 +77,10 @@ fn do_main(args: Cli) -> anyhow::Result<()> {
     }
 }
 
-main!(|args: Cli| {
-    match do_main(args) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Error: {:?}", e);
-        }
-    }
-});
+fn main() -> CliResult {
+    let args = Cli::from_args();
+    do_main(args).or_else(|e| {
+        error!("{:?}", e);
+        Ok(())
+    })
+}

--- a/examples/multioutput.rs
+++ b/examples/multioutput.rs
@@ -8,6 +8,7 @@
 
 use gpio_cdev::{Chip, LineRequestFlags};
 use quicli::prelude::*;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -48,9 +49,10 @@ fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     Ok(())
 }
 
-quicli::main!(|args: Cli| match do_main(args) {
-    Ok(()) => {}
-    Err(e) => {
-        println!("Error: {:?}", e);
-    }
-});
+fn main() -> CliResult {
+    let args = Cli::from_args();
+    do_main(args).or_else(|e| {
+        error!("{:?}", e);
+        Ok(())
+    })
+}

--- a/examples/multiread.rs
+++ b/examples/multiread.rs
@@ -8,6 +8,7 @@
 
 use gpio_cdev::{Chip, LineRequestFlags};
 use quicli::prelude::*;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -28,9 +29,10 @@ fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     Ok(())
 }
 
-quicli::main!(|args: Cli| match do_main(args) {
-    Ok(()) => {}
-    Err(e) => {
-        println!("Error: {:?}", e);
-    }
-});
+fn main() -> CliResult {
+    let args = Cli::from_args();
+    do_main(args).or_else(|e| {
+        error!("{:?}", e);
+        Ok(())
+    })
+}

--- a/examples/readall.rs
+++ b/examples/readall.rs
@@ -8,6 +8,7 @@
 
 use gpio_cdev::{Chip, LineRequestFlags};
 use quicli::prelude::*;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -26,9 +27,10 @@ fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     Ok(())
 }
 
-quicli::main!(|args: Cli| match do_main(args) {
-    Ok(()) => {}
-    Err(e) => {
-        println!("Error: {:?}", e);
-    }
-});
+fn main() -> CliResult {
+    let args = Cli::from_args();
+    do_main(args).or_else(|e| {
+        error!("{:?}", e);
+        Ok(())
+    })
+}

--- a/examples/readinput.rs
+++ b/examples/readinput.rs
@@ -8,6 +8,7 @@
 
 use gpio_cdev::{Chip, LineRequestFlags};
 use quicli::prelude::*;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -27,9 +28,10 @@ fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     Ok(())
 }
 
-quicli::main!(|args: Cli| match do_main(args) {
-    Ok(()) => {}
-    Err(e) => {
-        println!("Error: {:?}", e);
-    }
-});
+fn main() -> CliResult {
+    let args = Cli::from_args();
+    do_main(args).or_else(|e| {
+        error!("{:?}", e);
+        Ok(())
+    })
+}

--- a/examples/tit_for_tat.rs
+++ b/examples/tit_for_tat.rs
@@ -10,6 +10,7 @@ use gpio_cdev::{Chip, EventRequestFlags, EventType, LineRequestFlags};
 use quicli::prelude::*;
 use std::thread::sleep;
 use std::time::Duration;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -54,9 +55,10 @@ fn do_main(args: Cli) -> std::result::Result<(), gpio_cdev::Error> {
     Ok(())
 }
 
-quicli::main!(|args: Cli| match do_main(args) {
-    Ok(()) => {}
-    Err(e) => {
-        println!("Error: {:?}", e);
-    }
-});
+fn main() -> CliResult {
+    let args = Cli::from_args();
+    do_main(args).or_else(|e| {
+        error!("{:?}", e);
+        Ok(())
+    })
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -7,7 +7,6 @@
 // except according to those terms.
 
 use crate::IoctlKind;
-use libc;
 
 pub const GPIOHANDLES_MAX: usize = 64;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,7 +493,7 @@ impl Line {
         ffi::gpio_get_linehandle_ioctl(self.chip.file.as_raw_fd(), &mut request)?;
         Ok(LineHandle {
             line: self.clone(),
-            flags: flags,
+            flags,
             file: unsafe { File::from_raw_fd(request.fd) },
         })
     }
@@ -587,14 +587,14 @@ impl LineInfo {
 
     /// Name assigned to this chip if assigned
     pub fn name(&self) -> Option<&str> {
-        self.name.as_ref().map(|s| s.as_str())
+        self.name.as_deref()
     }
 
     /// The name of this GPIO line, such as the output pin of the line on the
     /// chip, a rail or a pin header name on a board, as specified by the gpio
     /// chip.
     pub fn consumer(&self) -> Option<&str> {
-        self.consumer.as_ref().map(|s| s.as_str())
+        self.consumer.as_deref()
     }
 
     /// Get the direction of this GPIO if configured
@@ -790,7 +790,7 @@ impl Lines {
         let lines = self.lines.clone();
         Ok(MultiLineHandle {
             lines: Lines { lines },
-            flags: flags,
+            flags,
             file: unsafe { File::from_raw_fd(request.fd) },
         })
     }
@@ -854,9 +854,7 @@ impl MultiLineHandle {
             return Err(invalid_err(n, values.len()));
         }
         let mut data: ffi::gpiohandle_data = unsafe { mem::zeroed() };
-        for i in 0..n {
-            data.values[i] = values[i];
-        }
+        data.values[..n].clone_from_slice(&values[..n]);
         ffi::gpiohandle_set_line_values_ioctl(self.file.as_raw_fd(), &mut data)?;
         Ok(())
     }


### PR DESCRIPTION
I have just blindly updated the dependencies. Just checked that the tests continue to run.
I am not sure about is the equivalent of the `io-driver` feature on `tokio` for the `1` version. I took `io-util` but it may be unnecessary as the tests run also without it.
A bit more work is necessary to update the `quicli` dependency to the latest version (`0.4`) but I do not have the time right now. Anyway it is just a dev dependency.