### PR TITLE
chore: bump tokio to v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
 
     # MSRV
     - env: TARGET=x86_64-unknown-linux-gnu DISABLE_TESTS=1
-      rust: 1.39.0
+      rust: 1.45.0
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## v0.5.0
+
+- Update Tokio to 1.x. #[55]((https://github.com/rust-embedded/gpio-cdev/pull/55).
+- Breaking change of `LineEventHandle::get_event()` which now expects `&mut self`.
+- MSRV is now 1.45.0
+
+
 ## v0.4.0 - 2020-08-01
 
 - Removed pub "errors" module.  Error now exposed at top level.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [features]
 default = []
-async-tokio = ["tokio", "futures", "mio"]
+async-tokio = ["tokio", "futures"]
 
 [[example]]
 name = "async_tokio"
@@ -23,13 +23,13 @@ required-features = ["async-tokio"]
 bitflags = "1.0"
 libc = "0.2"
 nix = "0.14"
-tokio = { version = "0.2", features = ["io-driver", "rt-threaded", "macros"], optional = true }
+tokio = { version = "1", features = ["io-std", "net"], optional = true }
 futures = { version = "0.3", optional = true }
-mio = { version = "0.6", optional = true }
 
 [dev-dependencies]
 quicli = "0.2"
 anyhow = "1.0"
+tokio = { version = "1", features = ["io-std", "rt-multi-thread", "macros", "net"] }
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ to be considered reliable.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.39.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.45.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License


### PR DESCRIPTION
Bump tokio to version 1.x.
Use tokio AsyncFd since tokio no longer exposes mio internals.