### PR TITLE
allow reading back the flags on a line handle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -692,6 +692,11 @@ impl LineHandle {
     pub fn line(&self) -> &Line {
         &self.line
     }
+
+    /// Get the flags with which this handle was created
+    pub fn flags(&self) -> LineRequestFlags {
+        self.flags
+    }
 }
 
 impl AsRawFd for LineHandle {


### PR DESCRIPTION
Currently, one has to store the flags separately if one wants to know the flags associated with a handle.﻿
