### PR TITLE
Allow nix 0.23.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Updated nix to allow both version `0.22` or `0.23`.
+
 ## [v0.5.0] - 2021-09-21
 
 - Update Tokio to 1.x. [#55](https://github.com/rust-embedded/gpio-cdev/pull/55).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["async-tokio"]
 [dependencies]
 bitflags = "1.3"
 libc = "0.2"
-nix = "0.22"
+nix = ">= 0.22, < 0.24"
 tokio = { version = "1", features = ["io-std", "net"], optional = true }
 futures = { version = "0.3", optional = true }
 


### PR DESCRIPTION
This crate compiles fine with nix 0.23 too. This change allows both nix 0.22 and 0.23 as dependency.