### PR TITLE
Do not run CI tests on mips

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -17,7 +17,7 @@ status = [
     "build (stable, x86_64-unknown-linux-gnu)",
     "build (stable, x86_64-unknown-linux-musl)",
 
-    "build (1.46.0, x86_64-unknown-linux-gnu)",
+    "build (1.59.0, x86_64-unknown-linux-gnu)",
 
     "checks"
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           args: --target=${{ matrix.TARGET }} --all-features
 
       - name: Test
+        if: ${{ ! contains(matrix.TARGET, 'mips') }} # https://github.com/rust-lang/rust/issues/108835
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
@@ -70,6 +71,7 @@ jobs:
           args: --target=${{ matrix.TARGET }}
 
       - name: Test all features
+        if: ${{ ! contains(matrix.TARGET, 'mips') }} # https://github.com/rust-lang/rust/issues/108835
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
@@ -113,4 +115,3 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
         include:
           # MSRV
-          - rust: 1.46.0
+          - rust: 1.59.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail
@@ -109,7 +109,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.46.0
+          toolchain: 1.59.0
           components: clippy
 
       - uses: actions-rs/clippy-check@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [v0.5.1] - 2021-11-22
 
 - Updated nix to version `0.23`.
+- MSRV is now 1.59.0.
 
 ## [v0.5.0] - 2021-09-21
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ to be considered reliable.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.46.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.59.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License


### PR DESCRIPTION
It seems we have been hit by https://github.com/rust-lang/rust/issues/108835 
Until that is fixed, let's not run the tests on mips targets.
Also, I raised the MSRV due to the dependencies.