### PR TITLE
Update MSRV to 1.82

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
         include:
           # MSRV
-          - rust: 1.65.0
+          - rust: 1.82.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail
@@ -109,7 +109,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.65.0
+          toolchain: 1.82.0
           components: clippy
 
       - uses: actions-rs/clippy-check@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
 - MSRV is now 1.82.0.
 
 ## [v0.6.0] - 2023-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- MSRV is now 1.82.0.
+
 ## [v0.6.0] - 2023-09-11
 
 - Updated nix to version `0.27`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["embedded", "hardware-support", "os", "os::unix-apis"]
 keywords = ["linux", "gpio", "gpiochip", "embedded"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+rust-version = "1.82"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ categories = ["embedded", "hardware-support", "os", "os::unix-apis"]
 keywords = ["linux", "gpio", "gpiochip", "embedded"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
-rust-version = "1.82"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ to be considered reliable.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.65.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License


### PR DESCRIPTION
backtrace requires Rust 1.82 or newer, use that as the MSRV.